### PR TITLE
Promote GitHub App usage for token generation

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,6 +15,13 @@ jobs:
           - full
 
     steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v3
 
       - uses: shivammathur/setup-php@v2
@@ -42,6 +49,6 @@ jobs:
       - name: Run
         run: composer run build -- $REMOTE $PACKAGE --type=$TYPE --unstable
         env:
-          REMOTE: https://${{ github.actor }}:${{ secrets.ROOTS_BOT_ACCESS_TOKEN }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_NAME }}.git
+          REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_NAME }}.git
           PACKAGE: ${{ github.repository_owner }}/${{ secrets.PACKAGE_NAME }}
           TYPE: ${{ matrix.release-type }}


### PR DESCRIPTION
Instead of using a PAT from a GitHub "personal" account, this change leverage GitHub Apps to generate a short-term and permission-limited token.

To achieve this, a (private) GitHub App must be created at the org level (https://github.com/organizations/roots/settings/apps)
* Enable content permission
* Install it in the same org, eventually limited to the relevant repositories (this one and the package ones)
* Generate a app key
* Create secrets with the app ID and the app Key