### PR TITLE
Use release type as package name in workflow

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Run
         run: composer run build -- $REMOTE $PACKAGE --type=$TYPE --unstable
         env:
-          REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_NAME }}.git
-          PACKAGE: ${{ github.repository_owner }}/${{ secrets.PACKAGE_NAME }}
+          REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}.git
+          PACKAGE: ${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}
           TYPE: ${{ matrix.release-type }}


### PR DESCRIPTION
This actually fixes a blocker for multi-type runs: the package name must change between release types.
An alternative would be to setup a job matrix and enforce a bit more manually package names.

In any case, the action secrets must be updated to reflect the different packages.
With this PR:
* Before: `PACKAGE_NAME: wordpress-full`
* After: `PACKAGE_PREFIX: wordpress-`