### PR TITLE
Drop installer requirement

### DIFF
--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -104,13 +104,6 @@ class Package extends CompletePackage implements JsonSerializable
                 $phpConstraint = new Constraint(Constraint::STR_OP_GE, $minPhpVersion),
                 Link::TYPE_REQUIRE,
                 $phpConstraint->getPrettyString()
-            ),
-            'roots/wordpress-core-installer' =>  new Link(
-                $this->getName(),
-                'roots/wordpress-core-installer',
-                new Constraint(Constraint::STR_OP_GE, '1.0.0'),
-                Link::TYPE_REQUIRE,
-                '^1.0'
             )
         ]);
 

--- a/tests/resources/package-composer.json
+++ b/tests/resources/package-composer.json
@@ -2,8 +2,7 @@
     "name": "roots/wordpress",
     "version": "5.2.1",
     "require": {
-        "php": ">= 5.6.20",
-        "roots/wordpress-core-installer": "^1.0"
+        "php": ">= 5.6.20"
     },
     "provide": {
         "wordpress/core-implementation": "5.2.1"

--- a/tests/resources/source-composer.json
+++ b/tests/resources/source-composer.json
@@ -10,8 +10,7 @@
         "wordpress/core-implementation": "5.8.3"
     },
     "require": {
-        "php": ">= 5.6.20",
-        "roots/wordpress-core-installer": "^1.0"
+        "php": ">= 5.6.20"
     },
     "suggest": {
         "ext-curl": "Performs remote request operations.",


### PR DESCRIPTION
This is a suggestion following https://twitter.com/gmazzap/status/1527976397117046784 comment.

It also align with the correct usage of installer, in the same `composer/installer` should (must?) be used with plugin:
* Packages are free of installer;
* Installer is required at "project" level, i.e. Bedrock.

This also adds the opportunity to use the generated package along with other installers, the most obvious one being https://github.com/johnpbloch/wordpress-core-installer.

The downside of all of this is the "risky" situations where the user must install two packages, the core and the installer, and manage them independently. 