### PR TITLE
Add a workflow to keep meta-package versions in sync

### DIFF
--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -51,11 +51,25 @@ jobs:
           TAGS: ${{ steps.tags-matrix.outputs.result }}
         run: echo "::set-output name=result::$(jq -r '.[0]' <<< "$TAGS")"
 
+  generate-token:
+    name: Token
+    runs-on: ubuntu-latest
+    outputs:
+      token: steps.generate-token.outputs.token
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
   tags:
     name: Tags
     runs-on: ubuntu-latest
     needs:
       - sync
+      - generate-token
     if: needs.sync.outputs.tags-matrix
     strategy:
       fail-fast: false
@@ -65,6 +79,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ secrets.META_PACKAGE }}
+          token: ${{ needs.generate-token.outputs.token }}
 
       - name: Create a tag
         uses: rickstaa/action-create-tag@v1
@@ -78,21 +93,15 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - sync
+      - generate-token
       - tags
     if: needs.sync.outputs.latest-release
     steps:
-      - name: Generate token
-        uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.BOT_APP_ID }}
-          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
-
       - name: Create a release
         uses: softprops/action-gh-release@v1
         if: ${{ ! inputs.dry-run }}
         with:
           repository: ${{ secrets.META_PACKAGE }}
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ needs.generate-token.outputs.token }}
           body: WordPress ${{ needs.sync.outputs.latest-release }}
           tag_name: ${{ needs.sync.outputs.latest-release }}

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -1,14 +1,13 @@
 name: Meta-package
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       dry-run:
-        required: true
+        required: false
         type: boolean
         default: true
-  # schedule:
-  #   - cron: '*/10 * * * *'
 
 jobs:
   sync:

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -33,7 +33,7 @@ jobs:
           META: ${{ secrets.META_PACKAGE }}
         with:
           script: |
-            const { PACKAGE } = process.env
+            const { PACKAGE, META } = process.env
             const currrentTags = github.rest.repos.listTags({
               owner: context.repo.owner,
               repo: META.substring(str.indexOf('/') + 1),

--- a/.github/workflows/metapackage.yml
+++ b/.github/workflows/metapackage.yml
@@ -1,0 +1,99 @@
+name: Meta-package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        required: true
+        type: boolean
+        default: true
+  # schedule:
+  #   - cron: '*/10 * * * *'
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+    outputs:
+      tags-matrix: steps.tags-matrix.outputs.result
+      latest-release: steps.latest-release.outputs.result
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ secrets.META_PACKAGE }}
+
+      - name: Get upstream package name
+        id: package
+        run: echo "::set-output name=package-name::$(jq -r '.require | map_values(select(. == "self.version")) | keys[0]' composer.json)"
+
+      - name: Generate diff of versions arrays
+        id: tags-matrix
+        uses: actions/github-script@v6
+        env:
+          PACKAGE: ${{ steps.package.outputs.package-name }}
+          META: ${{ secrets.META_PACKAGE }}
+        with:
+          script: |
+            const { PACKAGE } = process.env
+            const currrentTags = github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: META.substring(str.indexOf('/') + 1),
+            })
+            const upstreamTags = github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: PACKAGE.substring(str.indexOf('/') + 1),
+              per_page: 15
+            })
+            return upstreamTags.filter((tag) => !currrentTags.includes(tag))
+
+      - name: Extract latest release
+        id: latest-release
+        env:
+          TAGS: ${{ steps.tags-matrix.outputs.result }}
+        run: echo "::set-output name=result::$(jq -r '.[0]' <<< "$TAGS")"
+
+  tags:
+    name: Tags
+    runs-on: ubuntu-latest
+    needs:
+      - sync
+    if: needs.sync.outputs.tags-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.sync.outputs.tags-matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ secrets.META_PACKAGE }}
+
+      - name: Create a tag
+        uses: rickstaa/action-create-tag@v1
+        if: ${{ ! inputs.dry-run }}
+        with:
+          tag: ${{ matrix.tag }}
+          message: ${{ matrix.tag }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - sync
+      - tags
+    if: needs.sync.outputs.latest-release
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Create a release
+        uses: softprops/action-gh-release@v1
+        if: ${{ ! inputs.dry-run }}
+        with:
+          repository: ${{ secrets.META_PACKAGE }}
+          token: ${{ steps.generate-token.outputs.token }}
+          body: WordPress ${{ needs.sync.outputs.latest-release }}
+          tag_name: ${{ needs.sync.outputs.latest-release }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -53,3 +53,9 @@ jobs:
           REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}.git
           PACKAGE: ${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}
           TYPE: ${{ matrix.release-type }}
+
+  meta-package:
+    name: Meta-package
+    needs:
+      - packager
+    uses: ./.github/workflows/meta-package.yml


### PR DESCRIPTION
Better than on `roots/wordpress` as it keeps the workflow logic all in the same place.

Closes previous attempts (sorry for the noise!):
* https://github.com/roots/wordpress-packager/pull/537
* https://github.com/roots/wordpress/pull/42

Closes https://github.com/roots/wordpress/issues/1

---

A bit more explanations:
* It has an input to be able to dry-run for debugging before actual tags submission.
* It makes the diff based on tags listed throught GitHub Repo API.
* It pushes the tags on the meta-package repo (has to be done as a loop, via the matrix).
* It submits a release to properly resolves https://github.com/roots/wordpress/issues/1.