### PR TITLE
Fix export output values in workflow

### DIFF
--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -55,7 +55,7 @@ jobs:
     name: Token
     runs-on: ubuntu-latest
     outputs:
-      token: steps.generate-token.outputs.token
+      token: ${{ steps.generate-token.outputs.token }}
     steps:
       - name: Generate token
         uses: tibdex/github-app-token@v1


### PR DESCRIPTION
Related to https://github.com/roots/wordpress-packager/pull/570

Workflow error: https://github.com/roots/wordpress-packager/runs/8098441479?check_suite_focus=true#step:3:4