### PR TITLE
Fix actions deprecation warning

### DIFF
--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get upstream package name
         id: package
-        run: echo "::set-output name=package-name::$(jq -r '.require | map_values(select(. == "self.version")) | keys[0]' composer.json)"
+        run: echo "package-name=$(jq -r '.require | map_values(select(. == "self.version")) | keys[0]' composer.json)" >> $GITHUB_OUTPUT
 
       - name: Generate matrix from versions arrays
         id: tags-matrix


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/