### PR TITLE
Raise again the number of new possible tags

### DIFF
--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -38,7 +38,7 @@ jobs:
               github.rest.repos.listTags({
                 owner: context.repo.owner,
                 repo: PACKAGE.substring(PACKAGE.indexOf('/') + 1),
-                per_page: 50,
+                per_page: 100,
               }),
             ])
             const targetTags = await Promise.allSettled(


### PR DESCRIPTION
Follow up of https://github.com/roots/wordpress-packager/pull/588
Still to fix https://github.com/roots/wordpress/issues/44

The number of new WordPress releases per announcement is raising to the sky 🌪️