### PR TITLE
Publish releases with version notes for every tag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.js]
+indent_size = 2

--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -1,4 +1,4 @@
-module.exports = async ({ fetch }) => {
+module.exports = async ({ core, fetch }) => {
   const { VERSION } = process.env
   const slug = `version-${VERSION.replaceAll('.', '-')}`
 
@@ -19,7 +19,7 @@ module.exports = async ({ fetch }) => {
 
     return `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
   } catch (e) {
-    console.log(e)
+    core.warning(e)
 
     return `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
   }

--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -17,9 +17,7 @@ module.exports = async ({ fetch }) => {
       throw Error('Release body is empty or unexpected')
     }
 
-    return `_Sourced from [WordPress.org Documentation](${link})._
-
-<h2${body}`
+    return `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
   } catch (e) {
     console.log(e)
 

--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -1,0 +1,28 @@
+module.exports = async ({ fetch }) => {
+  const { VERSION } = process.env
+  const slug = `version-${VERSION.replaceAll('.', '-')}`
+
+  try {
+    const res = await fetch('https://wordpress.org/documentation/wp-json/wp/v2/wordpress-versions?per_page=50')
+    const data = await res.json()
+
+    const release = data.find((tag) => tag.slug === slug)
+    if (!release) {
+      throw Error('Release not found')
+    }
+
+    const { link } = release
+    const body = release.content?.rendered?.split('<h2', 4)[2]
+    if (!body) {
+      throw Error('Release body is empty or unexpected')
+    }
+
+    return `_Sourced from [WordPress.org Documentation](${link})._
+
+<h2${body}`
+  } catch (e) {
+    console.log(e)
+
+    return `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
+  }
+}

--- a/.github/scripts/tags.js
+++ b/.github/scripts/tags.js
@@ -1,0 +1,35 @@
+module.exports = async ({ github, context }) => {
+  const { PACKAGE, META } = process.env
+
+  const [{ data: currrentTags }, { data: upstreamTags }] = await Promise.all([
+    github.rest.repos.listTags({
+      owner: context.repo.owner,
+      repo: META.substring(META.indexOf('/') + 1),
+      per_page: 100,
+    }),
+    github.rest.repos.listTags({
+      owner: context.repo.owner,
+      repo: PACKAGE.substring(PACKAGE.indexOf('/') + 1),
+      per_page: 100,
+    }),
+  ])
+
+  const targetTags = await Promise.allSettled(
+    upstreamTags
+      .filter((tag) => !currrentTags.find((t) => t.name === tag.name))
+      .map((tag) =>
+        github.rest.git
+          .getRef({
+            owner: context.repo.owner,
+            repo: META.substring(META.indexOf('/') + 1),
+            ref: 'tags/' + tag.name,
+          })
+          .then(() => {})
+          .catch((res) => ({ tag: tag.name, status: res.status }))
+      )
+  )
+
+  return targetTags
+    .filter(({ value }) => value?.status === 404)
+    .map(({ value }) => value.tag)
+}

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -9,8 +9,7 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     outputs:
-      tags-matrix: ${{ steps.tags-matrix.outputs.result }}
-      latest-release: ${{ steps.latest-release.outputs.result }}
+      tags-matrix: ${{ steps.tags-matrix.outputs.result 
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,13 +58,6 @@ jobs:
               .filter(({ value }) => value?.status === 404)
               .map(({ value }) => value.tag)
 
-      # Can't be used as is: some version release batches don't override latest version
-      # - name: Extract latest release
-      #   id: latest-release
-      #   env:
-      #     TAGS: ${{ steps.tags-matrix.outputs.result }}
-      #   run: echo "::set-output name=result::$(jq -r '.[0]' <<< "$TAGS")"
-
   tags:
     name: Tags
     runs-on: ubuntu-latest
@@ -89,7 +81,16 @@ jobs:
           repository: ${{ secrets.META_PACKAGE }}
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Create a tag
+      - name: Retrieve version notes
+        id: notes
+        uses: actions/github-script@v6
+        env:
+          VERSION: ${{ matrix.tag }}
+        with:
+          script: |
+            // WIP
+
+      - name: Push tag
         env:
           TAG: ${{ matrix.tag }}
         run: |
@@ -98,25 +99,11 @@ jobs:
           git tag -a "${TAG}" -m "${TAG}"
           git push origin "${TAG}"
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs:
-      - sync
-      - tags
-    if: needs.sync.outputs.tags-matrix != '[]'
-    steps:
-      - name: Generate token
-        uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.BOT_APP_ID }}
-          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
-
-      - name: Create a release
+      - name: Publish release
         uses: softprops/action-gh-release@v1
         with:
           repository: ${{ secrets.META_PACKAGE }}
           token: ${{ steps.generate-token.outputs.token }}
-          body: WordPress ${{ needs.sync.outputs.latest-release }}
-          tag_name: ${{ needs.sync.outputs.latest-release }}
+          body: ${{ steps.notes.outputs.body }}
+          name: ${{ steps.notes.outputs.name }}
+          tag_name: ${{ matrix.tag }}

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -27,36 +27,8 @@ jobs:
           META: ${{ secrets.META_PACKAGE }}
         with:
           script: |
-            const { PACKAGE, META } = process.env
-            const [{ data: currrentTags }, { data: upstreamTags }] = await Promise.all([
-              github.rest.repos.listTags({
-                owner: context.repo.owner,
-                repo: META.substring(META.indexOf('/') + 1),
-                per_page: 100,
-              }),
-              github.rest.repos.listTags({
-                owner: context.repo.owner,
-                repo: PACKAGE.substring(PACKAGE.indexOf('/') + 1),
-                per_page: 100,
-              }),
-            ])
-            const targetTags = await Promise.allSettled(
-              upstreamTags
-                .filter((tag) => !currrentTags.find((t) => t.name === tag.name))
-                .map((tag) =>
-                  github.rest.git
-                    .getRef({
-                      owner: context.repo.owner,
-                      repo: META.substring(META.indexOf('/') + 1),
-                      ref: 'tags/' + tag.name,
-                    })
-                    .then(() => {})
-                    .catch((res) => ({ tag: tag.name, status: res.status }))
-                )
-            )
-            return targetTags
-              .filter(({ value }) => value?.status === 404)
-              .map(({ value }) => value.tag)
+            const tags = require('${{ github.workspace }}/.github/scripts/tags.js')
+            return await tags({ github, context })
 
   tags:
     name: Tags
@@ -89,27 +61,8 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const slug = `version-${VERSION.replaceAll('.', '-')}`
-            try {
-              const res = await fetch('https://wordpress.org/documentation/wp-json/wp/v2/wordpress-versions?per_page=50')
-              const data = await res.json()
-
-              const release = data.find((tag) => tag.slug === slug)
-              if (!release) { throw Error('Release not found') }
-
-              const { link } = release
-              const body = release.content?.rendered?.split('<h2', 4)[2]
-              if (!body) { throw Error('Release body is empty or unexpected') }
-
-              return `
-            _Sourced from [WordPress.org Documentation](${link})._
-
-            <h2${body}
-            `
-            } catch (e) {
-              console.log(e)
-              return `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
-            }
+            const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
+            return await notes({ fetch })
 
       - name: Push tag
         env:

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -9,7 +9,7 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     outputs:
-      tags-matrix: ${{ steps.tags-matrix.outputs.result 
+      tags-matrix: ${{ steps.tags-matrix.outputs.result }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -62,7 +62,7 @@ jobs:
           result-encoding: string
           script: |
             const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
-            return await notes({ fetch })
+            return await notes({ core, fetch })
 
       - name: Push tag
         env:

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -87,8 +87,29 @@ jobs:
         env:
           VERSION: ${{ matrix.tag }}
         with:
+          result-encoding: string
           script: |
-            // WIP
+            const slug = `version-${VERSION.replaceAll('.', '-')}`
+            try {
+              const res = await fetch('https://wordpress.org/documentation/wp-json/wp/v2/wordpress-versions?per_page=50')
+              const data = await res.json()
+
+              const release = data.find((tag) => tag.slug === slug)
+              if (!release) { throw Error('Release not found') }
+
+              const { link } = release
+              const body = release.content?.rendered?.split('<h2', 4)[2]
+              if (!body) { throw Error('Release body is empty or unexpected') }
+
+              return `
+            _Sourced from [WordPress.org Documentation](${link})._
+
+            <h2${body}
+            `
+            } catch (e) {
+              console.log(e)
+              return `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
+            }
 
       - name: Push tag
         env:
@@ -104,6 +125,6 @@ jobs:
         with:
           repository: ${{ secrets.META_PACKAGE }}
           token: ${{ steps.generate-token.outputs.token }}
-          body: ${{ steps.notes.outputs.body }}
-          name: ${{ steps.notes.outputs.name }}
+          body: ${{ steps.notes.outputs.result }}
+          name: Version ${{ matrix.tag }}
           tag_name: ${{ matrix.tag }}


### PR DESCRIPTION
Closes https://github.com/roots/wordpress/issues/47

Also restructure workflow scripts usage by moving them into proper files.
Not 100% sure first run is going to be a success, but hard to test as usual.