### PR TITLE
Refactor GitHub Actions workflows

### DIFF
--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -1,26 +1,46 @@
-module.exports = async ({ core, fetch }) => {
-  const { VERSION } = process.env
-  const slug = `version-${VERSION.replaceAll('.', '-')}`
+module.exports = async ({ github, core, fetch }) => {
+  const { TAGS_MATRIX, META_PACKAGE } = process.env
+  const tags = JSON.parse(TAGS_MATRIX)
 
-  try {
-    const res = await fetch('https://wordpress.org/documentation/wp-json/wp/v2/wordpress-versions?per_page=50')
-    const data = await res.json()
+  return Promise.allSettled(
+    tags.map((tag_name) =>
+      core.group(tag_name, async (tag_name) => {
+        const slug = `version-${tag_name.replaceAll('.', '-')}`
 
-    const release = data.find((tag) => tag.slug === slug)
-    if (!release) {
-      throw Error('Release not found')
-    }
+        try {
+          const res = await fetch(
+            'https://wordpress.org/documentation/wp-json/wp/v2/wordpress-versions?per_page=50'
+          )
+          const data = await res.json()
 
-    const { link } = release
-    const body = release.content?.rendered?.split('<h2', 4)[2]
-    if (!body) {
-      throw Error('Release body is empty or unexpected')
-    }
+          const release = data.find((tag) => tag.slug === slug)
+          if (!release) {
+            throw Error('Release not found')
+          }
 
-    return `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
-  } catch (e) {
-    core.warning(e)
+          const { link } = release
+          const body = release.content?.rendered?.split('<h2', 4)[2]
+          if (!body) {
+            throw Error('Release body is empty or unexpected')
+          }
 
-    return `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
-  }
+          const body = `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
+        } catch (e) {
+          core.error(e)
+
+          const body = `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
+        }
+
+        core.info('Publishing')
+        return github.rest.repos.createRelease({
+          owner: context.repo.owner,
+          repo: META_PACKAGE.substring(META_PACKAGE.indexOf('/') + 1),
+          tag_name,
+          body,
+          name: `Version ${tag_name}`,
+          make_latest: 'legacy',
+        })
+      })
+    )
+  )
 }

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -12,7 +12,7 @@ jobs:
     name: Package
     runs-on: ubuntu-latest
     outputs:
-      name: ${{ steps.package.outputs.package-name }}
+      package-name: ${{ steps.package.outputs.package-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -35,7 +35,7 @@ jobs:
         id: tags-matrix
         uses: actions/github-script@v6
         env:
-          PACKAGE: ${{ needs.package.outputs.name }}
+          PACKAGE: ${{ needs.package.outputs.package-name }}
           META: ${{ secrets.META_PACKAGE }}
         with:
           script: |

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       tags-matrix: ${{ steps.tags-matrix.outputs.result }}
     steps:
+      - uses: actions/checkout@v3
       - name: Generate matrix from versions arrays
         id: tags-matrix
         uses: actions/github-script@v6
@@ -47,6 +48,7 @@ jobs:
     needs:
       - sync
     if: needs.sync.outputs.tags-matrix != '[]'
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -64,17 +66,6 @@ jobs:
           repository: ${{ secrets.META_PACKAGE }}
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Retrieve version notes
-        id: notes
-        uses: actions/github-script@v6
-        env:
-          VERSION: ${{ matrix.tag }}
-        with:
-          result-encoding: string
-          script: |
-            const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
-            return await notes({ core, fetch })
-
       - name: Push tag
         env:
           TAG: ${{ matrix.tag }}
@@ -84,11 +75,29 @@ jobs:
           git tag -a "${TAG}" -m "${TAG}"
           git push origin "${TAG}"
 
-      - name: Publish release
-        uses: softprops/action-gh-release@v1
+  releases:
+    name: Releases
+    runs-on: ubuntu-latest
+    needs:
+      - sync
+      - tags
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
         with:
-          repository: ${{ secrets.META_PACKAGE }}
-          token: ${{ steps.generate-token.outputs.token }}
-          body: ${{ steps.notes.outputs.result }}
-          name: Version ${{ matrix.tag }}
-          tag_name: ${{ matrix.tag }}
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
+
+      - name: Retrieve version notes
+        uses: actions/github-script@v6
+        env:
+          TAGS_MATRIX: ${{ needs.sync.outputs.tags-matrix }}
+          META_PACKAGE: ${{ secrets.META_PACKAGE }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
+            await notes({ github, core, fetch })

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: ${{ secrets.META_PACKAGE }}
+          repository: ${{ vars.META_PACKAGE }}
 
       - name: Get upstream package name
         id: package
@@ -36,7 +36,7 @@ jobs:
         uses: actions/github-script@v6
         env:
           PACKAGE: ${{ needs.package.outputs.package-name }}
-          META: ${{ secrets.META_PACKAGE }}
+          META: ${{ vars.META_PACKAGE }}
         with:
           script: |
             const tags = require('${{ github.workspace }}/.github/scripts/tags.js')
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: ${{ secrets.META_PACKAGE }}
+          repository: ${{ vars.META_PACKAGE }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Push tag
@@ -95,7 +95,7 @@ jobs:
         uses: actions/github-script@v6
         env:
           TAGS_MATRIX: ${{ needs.sync.outputs.tags-matrix }}
-          META_PACKAGE: ${{ secrets.META_PACKAGE }}
+          META_PACKAGE: ${{ vars.META_PACKAGE }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -3,13 +3,16 @@ name: Meta-package
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  sync:
-    name: Sync
+  package:
+    name: Package
     runs-on: ubuntu-latest
     outputs:
-      tags-matrix: ${{ steps.tags-matrix.outputs.result }}
+      name: ${{ steps.package.outputs.package-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -19,11 +22,19 @@ jobs:
         id: package
         run: echo "package-name=$(jq -r '.require | map_values(select(. == "self.version")) | keys[0]' composer.json)" >> $GITHUB_OUTPUT
 
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+    needs:
+      - package
+    outputs:
+      tags-matrix: ${{ steps.tags-matrix.outputs.result }}
+    steps:
       - name: Generate matrix from versions arrays
         id: tags-matrix
         uses: actions/github-script@v6
         env:
-          PACKAGE: ${{ steps.package.outputs.package-name }}
+          PACKAGE: ${{ needs.package.outputs.name }}
           META: ${{ secrets.META_PACKAGE }}
         with:
           script: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Run
         run: composer run build -- $REMOTE $PACKAGE --type=$TYPE --unstable
         env:
-          REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}.git
-          PACKAGE: ${{ github.repository_owner }}/${{ secrets.PACKAGE_PREFIX }}${{ matrix.release-type }}
+          REMOTE: https://${{ github.actor }}:${{ steps.generate-token.outputs.token }}@github.com/${{ github.repository_owner }}/${{ vars.PACKAGE_PREFIX }}${{ matrix.release-type }}.git
+          PACKAGE: ${{ github.repository_owner }}/${{ vars.PACKAGE_PREFIX }}${{ matrix.release-type }}
           TYPE: ${{ matrix.release-type }}
 
   meta-package:


### PR DESCRIPTION
Apologies for this barely readable PR. 😬
The goal was to find a good compromise to make it run (the scripts folder is currently not available, workflow broken).

Steps to understand:
* Moving the release-notes process into a separate job
  * Comes with better performances, as it runs once for all tags
* The `notes` script now creates the release itself
  * Also way better workflow output
* Switching from GHA secrets to GHA variable
  * Required to split package name extraction and checkout local scripts
  * 👉 Could you please create these **variables** in [repo's settings](https://github.com/roots/wordpress-packager/settings/variables/actions), and delete respective secrets?
	  * `PACKAGE_PREFIX`: `wordpress-`
	  * `META_PACKAGE`: `roots/wordpress`