### PR TITLE
Fix release notes workflow

### DIFF
--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -1,4 +1,4 @@
-module.exports = async ({ github, core, fetch }) => {
+module.exports = async ({ github, context, core, fetch }) => {
   const { TAGS_MATRIX, META_PACKAGE } = process.env
   const tags = JSON.parse(TAGS_MATRIX)
 
@@ -25,8 +25,10 @@ module.exports = async ({ github, core, fetch }) => {
             throw Error('Release body is empty or unexpected')
           }
 
+          core.info(tag_name)
           body = `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
         } catch (e) {
+          core.info(tag_name)
           core.error(e)
 
           body = `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`

--- a/.github/scripts/notes.js
+++ b/.github/scripts/notes.js
@@ -6,6 +6,7 @@ module.exports = async ({ github, core, fetch }) => {
     tags.map((tag_name) =>
       core.group(tag_name, async (tag_name) => {
         const slug = `version-${tag_name.replaceAll('.', '-')}`
+        let body = ''
 
         try {
           const res = await fetch(
@@ -19,16 +20,16 @@ module.exports = async ({ github, core, fetch }) => {
           }
 
           const { link } = release
-          const body = release.content?.rendered?.split('<h2', 4)[2]
+          body = release.content?.rendered?.split('<h2', 4)[2]
           if (!body) {
             throw Error('Release body is empty or unexpected')
           }
 
-          const body = `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
+          body = `_Sourced from [WordPress.org Documentation](${link})._\n\n<h2${body}`
         } catch (e) {
           core.error(e)
 
-          const body = `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
+          body = `_Version notes available on [WordPress.org Documentation](https://wordpress.org/documentation/wordpress-version/${slug}/)._`
         }
 
         core.info('Publishing')

--- a/.github/workflows/meta-package.yml
+++ b/.github/workflows/meta-package.yml
@@ -77,27 +77,10 @@ jobs:
 
   releases:
     name: Releases
-    runs-on: ubuntu-latest
     needs:
       - sync
       - tags
-    steps:
-      - name: Generate token
-        uses: tibdex/github-app-token@v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.BOT_APP_ID }}
-          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v3
-
-      - name: Retrieve version notes
-        uses: actions/github-script@v6
-        env:
-          TAGS_MATRIX: ${{ needs.sync.outputs.tags-matrix }}
-          META_PACKAGE: ${{ vars.META_PACKAGE }}
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
-            await notes({ github, core, fetch })
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with: 
+      tags-matrix: ${{ needs.sync.outputs.tags-matrix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags-matrix:
+        description: Stringified JSON array of tag names
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      tags-matrix:
+        description: Stringified JSON array of tag names
+        type: string
+        required: true
+
+jobs:
+  notes:
+    name: Notes
+    runs-on: ubuntu-latest
+    environment: release-notes
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
+
+      - name: Retrieve version notes
+        uses: actions/github-script@v6
+        env:
+          TAGS_MATRIX: ${{ inputs.tags-matrix }}
+          META_PACKAGE: ${{ vars.META_PACKAGE }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const notes = require('${{ github.workspace }}/.github/scripts/notes.js')
+            await notes({ github, context, core, fetch })


### PR DESCRIPTION
Today was its first "production" run, which raised the following issues:
* Few code mistakes were included in the scripts. Fixed.
* The upstream release notes are released about ~30 min after the version zip distribution.
  * That specific job has been moved into its own actions file to allow manual runs.
  * This new action is using GHA environment delay feature, to be (almost) sure to get the notes.

---

⚠️ @swalkinshaw Please create an environment:
 * Go here: https://github.com/roots/wordpress-packager/settings/environments/new
 * Name: `release-notes`
 * Enable "Wait timer" and set it to 45 min
 * Save
 * Thanks!