### PR TITLE
Gate scheduled build workflow behind lightweight release check

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,8 +6,55 @@ on:
     - cron: '*/10 * * * *'
 
 jobs:
+  check:
+    name: Check for new releases
+    runs-on: ubuntu-latest
+    outputs:
+      has-new: ${{ steps.check.outputs.has-new }}
+    steps:
+      - name: Check for unpackaged WordPress releases
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE_PREFIX: ${{ vars.PACKAGE_PREFIX }}
+        run: |
+          set -euo pipefail
+
+          api_url='https://api.wordpress.org/core/version-check/1.7/'
+
+          # Fetch stable + beta into separate files
+          curl -sf "$api_url" -o /tmp/wp-stable.json
+          curl -sf "${api_url}?channel=beta" -o /tmp/wp-beta.json
+
+          has_new=false
+          for type in full no-content; do
+            api_type=$(echo "$type" | tr '-' '_')
+
+            # Get versions that have a download URL for this package type
+            # Mirrors PHP filter: response == "autoupdate" && packages.<type> is truthy
+            versions=$(jq -r '[.offers[] | select(.response == "autoupdate" and .packages.'"${api_type}"') | .version] | unique | .[]' \
+              /tmp/wp-stable.json /tmp/wp-beta.json | sort -u)
+
+            echo "Versions available for ${type}: $(echo $versions | tr '\n' ' ')"
+
+            tags=$(gh api "repos/${OWNER}/${PACKAGE_PREFIX}${type}/git/refs/tags" \
+              --paginate --jq '.[].ref | ltrimstr("refs/tags/")')
+
+            for version in $versions; do
+              if ! echo "$tags" | grep -qx "$version"; then
+                echo "New release found: $version (missing from ${PACKAGE_PREFIX}${type})"
+                has_new=true
+              fi
+            done
+          done
+
+          echo "has-new=${has_new}" >> "$GITHUB_OUTPUT"
+
   packager:
     name: ${{ matrix.release-type }}
+    needs: [check]
+    if: always() && (needs.check.outputs.has-new == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -57,6 +104,8 @@ jobs:
   meta-package:
     name: Meta-package
     needs:
+      - check
       - packager
+    if: always() && needs.packager.result == 'success' && (needs.check.outputs.has-new == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/meta-package.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add a lightweight `check` job to the scheduled build workflow (`*/10 * * * *`).
- `check` fetches stable + beta WordPress offers and compares them against tags in
  `roots/wordpress-full` and `roots/wordpress-no-content`.
- Version filtering is package-type aware (`packages.<type>` must be present),
  matching existing packager behavior.
- Run expensive jobs only when needed:
  - `packager` runs when `has-new == true` or `workflow_dispatch`
  - `meta-package` runs only if `packager` succeeded

## Why
Most scheduled runs do full setup/build work even when no new WordPress release exists.
This repository is currently the largest consumer of our Actions budget.

## Expected impact
- No-release runs drop from multiple billed jobs to 1 (check only)
- Expected substantial reduction in this repo's billed minutes (roughly ~75% baseline)
- Polling cadence remains every 10 minutes (no release-latency change)

## Behavior notes
- Manual dispatch always runs the full pipeline
- If `check` fails on scheduled runs, downstream jobs do not run (fail-safe)

* * *

<img width="792" height="758" alt="image" src="https://github.com/user-attachments/assets/57eaee11-a871-4767-8f8b-871aef105841" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)